### PR TITLE
Respect minimum fraction digits when  formatted number has no fractional part

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "jest": "^27.2.0"
   }
 }

--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -22,7 +22,10 @@
 		} else if(separators && separators.hundreds) {
 			sNumParts[0] = sNumParts[0].replace(/(\d)(?=(\d\d)+(?!\d))/g, "$1" + separators.hundreds);
 		}
-		if(sNumParts.length === 2 && options && options.minimumFractionDigits > 0) {
+		if(options && options.minimumFractionDigits > 0) {
+			if (sNumParts.length !== 2) {
+				sNumParts[1] = '';
+			}
 			sNumParts[1] = sNumParts[1].padEnd(options.minimumFractionDigits, '0');
 		}
 		sNum = sNumParts.join(separators.decimal);

--- a/test/polyfill.number.toLocaleString.spec.js
+++ b/test/polyfill.number.toLocaleString.spec.js
@@ -1,0 +1,14 @@
+const defaultLocales = 'en';
+
+describe('Number.toLocaleString polyfill', () => {
+    it('should respect `minimumFractionDigits` option', ()=>{
+        const withoutFraction = 42;
+        const withFraction = 42.1;
+
+        expect(withoutFraction.toLocaleString(defaultLocales, {minimumFractionDigits: 1})).toEqual('42.0')
+
+        expect(withFraction.toLocaleString(defaultLocales, {minimumFractionDigits: 2})).toEqual('42.10')
+
+        expect(withFraction.toLocaleString(defaultLocales,)).toEqual('42.1')
+    })
+});


### PR DESCRIPTION
When we set `minimumFractionDigits` option, it should be respected also when the number has no fraction digits ie.:
```
> (42).toLocaleString('en', {minimumFractionDigits: 2})
'42.00'
```